### PR TITLE
CF_EXTERN_C_BEGIN

### DIFF
--- a/Sources/CAudioKitEX/Nodes/CallbackInstrumentDSP.mm
+++ b/Sources/CAudioKitEX/Nodes/CallbackInstrumentDSP.mm
@@ -2,6 +2,7 @@
 
 #include "DSPBase.h"
 #import "Internals/RingBuffer.h"
+#import "CAudioKit.h"
 
 using AudioKit::RingBuffer;
 
@@ -70,7 +71,7 @@ private:
     CMIDICallback callback = nullptr;
 };
 
-AK_API void akCallbackInstrumentSetCallback(DSPRef dsp, CMIDICallback callback) {
+void akCallbackInstrumentSetCallback(DSPRef dsp, CMIDICallback callback) {
     static_cast<CallbackInstrumentDSP*>(dsp)->setCallback(callback);
 }
 

--- a/Sources/CAudioKitEX/include/CAudioKit.h
+++ b/Sources/CAudioKitEX/include/CAudioKit.h
@@ -32,8 +32,10 @@ FOUNDATION_EXPORT const unsigned char AudioKitVersionString[];
 // Swift/ObjC/C/C++ Inter-operability
 #import "Interop.h"
 
+CF_EXTERN_C_BEGIN
 typedef void (^CMIDICallback)(uint8_t, uint8_t, uint8_t);
-AK_API void akCallbackInstrumentSetCallback(DSPRef dsp, CMIDICallback callback);
+void akCallbackInstrumentSetCallback(DSPRef dsp, CMIDICallback callback);
+CF_EXTERN_C_END
 
 // Misc
 #import "BufferedAudioBus.h"

--- a/Sources/CAudioKitEX/include/DSPBase.h
+++ b/Sources/CAudioKitEX/include/DSPBase.h
@@ -7,33 +7,37 @@
 
 #include <stdarg.h>
 
-AK_API DSPRef akCreateDSP(OSType code);
-AK_API AUParameterAddress akGetParameterAddress(const char* name);
+CF_EXTERN_C_BEGIN
 
-AK_API AUInternalRenderBlock internalRenderBlockDSP(DSPRef pDSP);
+DSPRef akCreateDSP(OSType code);
+AUParameterAddress akGetParameterAddress(const char* name);
 
-AK_API size_t inputBusCountDSP(DSPRef pDSP);
-AK_API bool canProcessInPlaceDSP(DSPRef pDSP);
+AUInternalRenderBlock internalRenderBlockDSP(DSPRef pDSP);
 
-AK_API void setBufferDSP(DSPRef pDSP, AudioBufferList* buffer, size_t busIndex);
-AK_API void allocateRenderResourcesDSP(DSPRef pDSP, uint32_t channelCount, double sampleRate);
-AK_API void deallocateRenderResourcesDSP(DSPRef pDSP);
-AK_API void resetDSP(DSPRef pDSP);
+size_t inputBusCountDSP(DSPRef pDSP);
+bool canProcessInPlaceDSP(DSPRef pDSP);
 
-AK_API void setParameterValueDSP(DSPRef pDSP, AUParameterAddress address, AUValue value);
-AK_API AUValue getParameterValueDSP(DSPRef pDSP, AUParameterAddress address);
+void setBufferDSP(DSPRef pDSP, AudioBufferList* buffer, size_t busIndex);
+void allocateRenderResourcesDSP(DSPRef pDSP, uint32_t channelCount, double sampleRate);
+void deallocateRenderResourcesDSP(DSPRef pDSP);
+void resetDSP(DSPRef pDSP);
 
-AK_API void setBypassDSP(DSPRef pDSP, bool bypassed);
-AK_API bool getBypassDSP(DSPRef pDSP);
+void setParameterValueDSP(DSPRef pDSP, AUParameterAddress address, AUValue value);
+AUValue getParameterValueDSP(DSPRef pDSP, AUParameterAddress address);
 
-AK_API void initializeConstantDSP(DSPRef pDSP, AUValue value);
+void setBypassDSP(DSPRef pDSP, bool bypassed);
+bool getBypassDSP(DSPRef pDSP);
 
-AK_API void setWavetableDSP(DSPRef pDSP, const float* table, size_t length, int index);
+void initializeConstantDSP(DSPRef pDSP, AUValue value);
 
-AK_API void deleteDSP(DSPRef pDSP);
+void setWavetableDSP(DSPRef pDSP, const float* table, size_t length, int index);
+
+void deleteDSP(DSPRef pDSP);
 
 /// Reset random seed to ensure deterministic results in tests.
-AK_API void akSetSeed(unsigned int);
+void akSetSeed(unsigned int);
+
+CF_EXTERN_C_END
 
 #ifdef __cplusplus
 

--- a/Sources/CAudioKitEX/include/Interop.h
+++ b/Sources/CAudioKitEX/include/Interop.h
@@ -5,12 +5,6 @@
 /// Pointer to an instance of an DSPBase subclass
 typedef struct DSPBase* DSPRef;
 
-#ifdef __cplusplus
-#define AK_API extern "C"
-#else
-#define AK_API
-#endif
-
 /// MIDI Constants
 #define MIDI_NOTE_ON 0x90
 #define MIDI_NOTE_OFF 0x80

--- a/Sources/CAudioKitEX/include/SequencerEngine.h
+++ b/Sources/CAudioKitEX/include/SequencerEngine.h
@@ -30,14 +30,16 @@ typedef struct {
 
 typedef struct SequencerEngine* SequencerEngineRef;
 
+CF_EXTERN_C_BEGIN
+
 /// Creates the audio-thread-only state for the sequencer.
-AK_API SequencerEngineRef akSequencerEngineCreate(void);
+SequencerEngineRef akSequencerEngineCreate(void);
 
 /// Release ownership of the sequencer. Sequencer is deallocated when no render observers are live.
-AK_API void akSequencerEngineRelease(SequencerEngineRef engine);
+void akSequencerEngineRelease(SequencerEngineRef engine);
 
 /// Updates the sequence and returns a new render observer.
-AK_API AURenderObserver akSequencerEngineUpdateSequence(SequencerEngineRef engine,
+AURenderObserver akSequencerEngineUpdateSequence(SequencerEngineRef engine,
                                                         const SequenceEvent* events,
                                                         size_t eventCount,
                                                         SequenceSettings settings,
@@ -45,17 +47,19 @@ AK_API AURenderObserver akSequencerEngineUpdateSequence(SequencerEngineRef engin
                                                         AUScheduleMIDIEventBlock block);
 
 /// Returns the sequencer playhead position in beats.
-AK_API double akSequencerEngineGetPosition(SequencerEngineRef engine);
+double akSequencerEngineGetPosition(SequencerEngineRef engine);
 
 /// Move the playhead to a location in beats.
-AK_API void akSequencerEngineSeekTo(SequencerEngineRef engine, double position);
+void akSequencerEngineSeekTo(SequencerEngineRef engine, double position);
 
-AK_API void akSequencerEngineSetPlaying(SequencerEngineRef engine, bool playing);
+void akSequencerEngineSetPlaying(SequencerEngineRef engine, bool playing);
 
-AK_API bool akSequencerEngineIsPlaying(SequencerEngineRef engine);
+bool akSequencerEngineIsPlaying(SequencerEngineRef engine);
 
 /// Stop all notes currently playing.
-AK_API void akSequencerEngineStopPlayingNotes(SequencerEngineRef engine);
+void akSequencerEngineStopPlayingNotes(SequencerEngineRef engine);
 
 /// Update sequencer tempo.
-AK_API void akSequencerEngineSetTempo(SequencerEngineRef engine, double tempo);
+void akSequencerEngineSetTempo(SequencerEngineRef engine, double tempo);
+
+CF_EXTERN_C_END


### PR DESCRIPTION
Minor cleanup to use Apple macro instead of our own.