### PR TITLE
Revert CallbackInstrument timer to NSTimer

### DIFF
--- a/Sources/CAudioKitEX/Nodes/CallbackInstrumentDSP.mm
+++ b/Sources/CAudioKitEX/Nodes/CallbackInstrumentDSP.mm
@@ -13,26 +13,21 @@ public:
     // MARK: Member Functions
 
     RingBuffer<AUMIDIEvent> midiBuffer;
-    dispatch_source_t timer;
+    NSTimer* timer;
 
     CallbackInstrumentDSP() {
         // Hopefully this polling interval is ok.
-        static dispatch_once_t onceToken;
-        static dispatch_queue_t timerQueue;
-        dispatch_once(&onceToken, ^{
-            timerQueue = dispatch_queue_create("audio.kit.timer.queue", DISPATCH_QUEUE_CONCURRENT);
-        });
-        timer = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, timerQueue);
-        dispatch_source_set_timer(timer, DISPATCH_TIME_NOW, 0.01, 0);
-        dispatch_source_set_event_handler(timer, ^{
+        timer = [NSTimer timerWithTimeInterval:0.01
+                                       repeats:true
+                                         block:^(NSTimer * _Nonnull timer) {
             consumer();
-        });
-        dispatch_resume(timer);
+        }];
+        NSRunLoop *runner = [NSRunLoop currentRunLoop];
+        [runner addTimer:timer forMode: NSDefaultRunLoopMode];
     }
 
     ~CallbackInstrumentDSP() {
-        dispatch_source_cancel(timer);
-        timer = nil;
+        [timer invalidate];
     }
 
     void process(FrameRange range) override {


### PR DESCRIPTION
This reverts the changes made here: https://github.com/AudioKit/AudioKit/pull/2632.

The CallbackInstrument is now using NSTimer back again, but with a run loop depending on the thread the instrument was instantiated.

This could fix https://github.com/AudioKit/AudioKitEX/issues/5.
