### PR TITLE
Fix incorrect sorting of certain sequences

### DIFF
--- a/Sources/AudioKitEX/Sequencing/Sequence.swift
+++ b/Sources/AudioKitEX/Sequencing/Sequence.swift
@@ -40,12 +40,9 @@ extension Array where Element == SequenceEvent {
         return self.sorted(by: { (event1:SequenceEvent, event2:SequenceEvent) -> Bool in
             let event1Beat = event1.beat
             let event2Beat = event2.beat
-            let simultaneous = (event1Beat == event2Beat) && (event1.data1 == event2.data1)
-            if isNoteOn(event1.status) && isNoteOff(event2.status) && simultaneous {
-                return false
-            }
-            if isNoteOff(event1.status) && isNoteOn(event2.status) && simultaneous {
-                return true
+            if event1Beat == event2Beat {
+                if isNoteOn(event1.status) && isNoteOff(event2.status) { return false }
+                if isNoteOff(event1.status) && isNoteOn(event2.status) { return true }
             }
             return event1Beat < event2Beat
         })

--- a/Tests/AudioKitEXTests/SequenceTests.swift
+++ b/Tests/AudioKitEXTests/SequenceTests.swift
@@ -52,5 +52,55 @@ class NoteEventSequenceTests: XCTestCase {
         XCTAssertEqual(seq.notes[1].noteOn.data1, 62)
     }
 
+    func testNoteOffAlwaysBeforeNoteOnInBeatTimeOrdered() {
+        let noteOn = SequenceEvent(status: noteOnByte, data1: 60, data2: 0, beat: 0)
+        let noteOff = SequenceEvent(status: noteOffByte, data1: 60, data2: 0, beat: 0)
+        let otherNoteOn = SequenceEvent(status: noteOnByte, data1: 61, data2: 0, beat: 0)
+
+        let sequences = [
+            [noteOn, noteOff, otherNoteOn],
+            [noteOn, otherNoteOn, noteOff],
+            [noteOff, noteOn , otherNoteOn],
+            [noteOff, otherNoteOn, noteOn],
+            [otherNoteOn, noteOn, noteOff],
+            [otherNoteOn, noteOff, noteOn]
+        ]
+
+        for sequence in sequences {
+            let ordered = sequence.beatTimeOrdered()
+            XCTAssertLessThan(ordered.firstIndex(of: noteOff)!, ordered.firstIndex(of: noteOn)!)
+        }
+    }
+
+    func testEarlierNoteBeforeInBeatTimeOrderedForSameNoteSameStatus() {
+        let earlier = SequenceEvent(status: noteOnByte, data1: 60, data2: 0, beat: 0)
+        let later = SequenceEvent(status: noteOnByte, data1: 60, data2: 0, beat: 1)
+
+        let sequences = [
+            [earlier, later],
+            [later, earlier],
+        ]
+
+        for sequence in sequences {
+            let ordered = sequence.beatTimeOrdered()
+            XCTAssertLessThan(ordered.firstIndex(of: earlier)!, ordered.firstIndex(of: later)!)
+        }
+    }
+
+    func testEarlierNoteBeforeInBeatTimeOrderedForSameNoteDifferentStatus() {
+        let earlier = SequenceEvent(status: noteOnByte, data1: 60, data2: 0, beat: 0)
+        let later = SequenceEvent(status: noteOffByte, data1: 60, data2: 0, beat: 1)
+
+        let sequences = [
+            [earlier, later],
+            [later, earlier],
+        ]
+
+        for sequence in sequences {
+            let ordered = sequence.beatTimeOrdered()
+            XCTAssertLessThan(ordered.firstIndex(of: earlier)!, ordered.firstIndex(of: later)!)
+        }
+    }
+
 }
 #endif


### PR DESCRIPTION
Certain combinations of sequence events were incorrectly sorted. E.g.:


1. Note 60 ON at beat 0
2. Note 61 ON at beat 0
3. Note 60 OFF at beat 0

