### PR TITLE
Sequencer check trackbounds notes

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/AudioKit/AudioKit",
         "state": {
           "branch": null,
-          "revision": "3360ddec30659447201a9ca4360d20cd924aab32",
-          "version": "5.3.0"
+          "revision": "e7f37266dc9200f04a2646b108acae98c87f8e46",
+          "version": "5.4.1"
         }
       }
     ]

--- a/Sources/AudioKitEX/Sequencing/Sequence.swift
+++ b/Sources/AudioKitEX/Sequencing/Sequence.swift
@@ -69,9 +69,10 @@ public struct NoteEventSequence: Equatable {
     /// - Parameters:
     ///   - notes: Array of sequence notes
     ///   - events: Array of sequence events
-    public init(notes: [SequenceNote] = [], events: [SequenceEvent] = []) {
+    public init(notes: [SequenceNote] = [], events: [SequenceEvent] = [], totalDuration: Double = 0.0) {
         self.notes = notes
         self.events = events
+        self.totalDuration = totalDuration
     }
 
     /// Add a note

--- a/Sources/AudioKitEX/Sequencing/Sequence.swift
+++ b/Sources/AudioKitEX/Sequencing/Sequence.swift
@@ -63,6 +63,7 @@ public struct NoteEventSequence: Equatable {
     public var notes: [SequenceNote]
     /// Array of sequence events
     public var events: [SequenceEvent]
+    private(set) var totalDuration: Double = 0.0
 
     /// Initialize with notes and events
     /// - Parameters:
@@ -85,6 +86,7 @@ public struct NoteEventSequence: Equatable {
                              channel: MIDIChannel = 0,
                              position: Double,
                              duration: Double) {
+        totalDuration += duration
         var newNote = SequenceNote()
 
         newNote.noteOn.status = noteOnByte

--- a/Sources/AudioKitEX/Sequencing/SequencerTrack.swift
+++ b/Sources/AudioKitEX/Sequencing/SequencerTrack.swift
@@ -83,7 +83,16 @@ open class SequencerTrack {
     }
 
     /// Sequence on this track
-    public var sequence = NoteEventSequence() { didSet { updateSequence() } }
+    public var sequence = NoteEventSequence() {
+        willSet {
+            if newValue.totalDuration >= length {
+                Log("Warning: Note event sequence duration exceeds the bounds of the sequencer track")
+                length = newValue.totalDuration + 0.01
+                Log("Track length set to \(length) beats")
+            }
+        }
+        didSet { updateSequence() }
+    }
 
     /// Add a MIDI noteOn and noteOff to the track
     /// - Parameters:

--- a/Tests/AudioKitEXTests/SequenceTests.swift
+++ b/Tests/AudioKitEXTests/SequenceTests.swift
@@ -25,7 +25,7 @@ class NoteEventSequenceTests: XCTestCase {
         newNote.noteOff.data2 = 127
         newNote.noteOff.beat = 2.0
         
-        XCTAssertEqual(seq, NoteEventSequence(notes: [newNote], events: []))
+        XCTAssertEqual(seq, NoteEventSequence(notes: [newNote], events: [], totalDuration: 1.0))
     }
 
     func testRemoveNote() {

--- a/Tests/AudioKitEXTests/SequencerTrackTests.swift
+++ b/Tests/AudioKitEXTests/SequencerTrackTests.swift
@@ -114,5 +114,26 @@ class SequencerTrackTests: XCTestCase {
 
     }
 
+    func testNoteBounds() {
+        let engine = AudioEngine()
+        let sampler = AppleSampler()
+        let sampleURL = Bundle.module.url(forResource: "TestResources/sinechirp", withExtension: "wav")!
+        let audioFile = try! AVAudioFile(forReading: sampleURL)
+        try! sampler.loadAudioFile(audioFile)
+
+        let track = SequencerTrack(targetNode: sampler)
+        engine.output = sampler
+
+        track.add(noteNumber: 60, position: 0.0, duration: 1.0)
+        track.add(noteNumber: 60, position: 1.0, duration: 1.0)
+        track.add(noteNumber: 60, position: 2.0, duration: 1.0)
+        track.add(noteNumber: 60, position: 3.0, duration: 1.0)
+
+        track.playFromStart()
+        XCTAssertTrue(track.isPlaying)
+        let audio = engine.startTest(totalDuration: 5.0)
+        audio.append(engine.render(duration: 5.0))
+        testMD5(audio)
+    }
 }
 #endif

--- a/Tests/AudioKitEXTests/ValidatedMD5s.swift
+++ b/Tests/AudioKitEXTests/ValidatedMD5s.swift
@@ -20,5 +20,6 @@ let validatedMD5s: [String: String] = [
     "-[SequencerTrackTests testChangeTempo]": "3e05405bead660d36ebc9080920a6c1e",
     "-[SequencerTrackTests testLoop]": "3a7ebced69ddc6669932f4ee48dabe2b",
     "-[SequencerTrackTests testOneShot]": "3fbf53f1139a831b3e1a284140c8a53c",
-    "-[SequencerTrackTests testTempo]": "1eb7efc6ea54eafbe616dfa8e1a3ef36"
+    "-[SequencerTrackTests testTempo]": "1eb7efc6ea54eafbe616dfa8e1a3ef36",
+    "-[SequencerTrackTests testNoteBounds]": "6679c7b949d28130549c6a1eb4ceaf59"
 ]


### PR DESCRIPTION
Changes:
1. Add `totalDuration` getter in `Sequence.swift`
2. Update `totalDuration` every time a new note event is added in `Sequence.swift`
3. Add property observer to `sequence` in `SequencerTrack.swift`
4. Add warnings and change the track length if the `totalDuration` exceeds the bounds of the track
5. Add `testNoteBounds()` with passing MD5
6. Update `Package.resolved` to current AK
7. Add `totalDuration` to `NoteEventSequence` initializer
8. Change `testAdd()` to use new initializer

This should help with #10 and #12