### PR TITLE
Fix rounding errors in parameter automation

### DIFF
--- a/Sources/AudioKitEX/Automation/NodeParameter+Automation.swift
+++ b/Sources/AudioKitEX/Automation/NodeParameter+Automation.swift
@@ -47,8 +47,8 @@ extension NodeParameter {
             
             guard let observer = ParameterAutomationGetRenderObserver(parameter.address,
                                                                       avAudioNode.auAudioUnit.scheduleParameterBlock,
-                                                                      Float(Settings.sampleRate),
-                                                                      Float(lastTime.sampleTime),
+                                                                      Double(Settings.sampleRate),
+                                                                      Double(lastTime.sampleTime),
                                                                       automationBaseAddress,
                                                                       events.count) else { return }
             

--- a/Sources/CAudioKitEX/include/ParameterAutomation.h
+++ b/Sources/CAudioKitEX/include/ParameterAutomation.h
@@ -26,8 +26,8 @@ struct AutomationEvent {
 /// Returns a render observer block which will apply the automation to the selected parameter.
 AURenderObserver ParameterAutomationGetRenderObserver(AUParameterAddress address,
                                                       AUScheduleParameterBlock scheduleParameterBlock,
-                                                      float sampleRate,
-                                                      float startSampleTime,
+                                                      double sampleRate,
+                                                      double startSampleTime,
                                                       const struct AutomationEvent* events,
                                                       size_t count);
 


### PR DESCRIPTION
- Convert `time` -> `sample time` instead of `sample time` -> `time`
- This will be more precise as we are not working with fractions
- Use double instead of float in APIs (`AudioTimeStamp->mSampleTime` is double)