### PR TITLE
Basic support for non-realtime effects

### DIFF
--- a/Sources/AudioKitEX/Node+AudioKitAU.swift
+++ b/Sources/AudioKitEX/Node+AudioKitAU.swift
@@ -63,3 +63,9 @@ public func instantiate(effect code: String) -> AVAudioNode {
 public func instantiate(mixer code: String) -> AVAudioNode {
     instantiate(componentDescription: AudioComponentDescription(mixer: code))
 }
+
+/// Create a non-realtime effect for the given unique identifier
+/// - Parameter code: Unique four letter identifier
+public func instantiate(nonRealTimeEffect code: String) -> AVAudioNode {
+    instantiate(componentDescription: AudioComponentDescription(nonRealTimeEffect: code))
+}

--- a/Sources/CAudioKitEX/Internals/DSPBase.mm
+++ b/Sources/CAudioKitEX/Internals/DSPBase.mm
@@ -100,8 +100,13 @@ AUInternalRenderBlock DSPBase::internalRenderBlock()
     {
 
         assert( (outputBusNumber == 0) && "We don't yet support multiple output busses" );
+
+        AUAudioFrameCount inputFrameCount = framesToPull(frameCount);
+
+        assert( !(bCanProcessInPlace && (inputFrameCount != frameCount)) && "Can't process in place when inputFrameCount differs from frameCount" );
+
         if (pullInputBlock) {
-            if (bCanProcessInPlace && inputBufferLists.size() == 1) {
+            if (bCanProcessInPlace && (inputBufferLists.size() == 1)) {
                 // pull input directly to output buffer
                 inputBufferLists[0] = outputData;
                 AudioUnitRenderActionFlags inputFlags = 0;
@@ -112,13 +117,13 @@ AUInternalRenderBlock DSPBase::internalRenderBlock()
                 for (size_t i = 0; i < inputBufferLists.size(); i++) {
                     inputBufferLists[i] = internalBufferLists[i];
                     
-                    UInt32 byteSize = frameCount * sizeof(float);
+                    UInt32 byteSize = inputFrameCount * sizeof(float);
                     for (UInt32 ch = 0; ch < inputBufferLists[i]->mNumberBuffers; ch++) {
                         inputBufferLists[i]->mBuffers[ch].mDataByteSize = byteSize;
                     }
                     
                     AudioUnitRenderActionFlags inputFlags = 0;
-                    pullInputBlock(&inputFlags, timestamp, frameCount, i, inputBufferLists[i]);
+                    pullInputBlock(&inputFlags, timestamp, inputFrameCount, i, inputBufferLists[i]);
                 }
             }
         }

--- a/Sources/CAudioKitEX/include/DSPBase.h
+++ b/Sources/CAudioKitEX/include/DSPBase.h
@@ -170,7 +170,6 @@ public:
 
         if (midiEvent.length != 3) return;
         uint8_t status = midiEvent.data[0] & 0xF0;
-        uint8_t channel = midiEvent.data[0] & 0x0F;
         switch (status) {
             case MIDI_NOTE_ON : {
                 uint8_t note = midiEvent.data[1];

--- a/Sources/CAudioKitEX/include/DSPBase.h
+++ b/Sources/CAudioKitEX/include/DSPBase.h
@@ -136,6 +136,8 @@ public:
     void setBuffer(AudioBufferList* buffer, size_t busIndex);
     size_t getInputBusCount() const { return inputBufferLists.size(); }
 
+    virtual AUAudioFrameCount framesToPull(AUAudioFrameCount requestedOutputFrameCount) { return requestedOutputFrameCount; };
+
     /// Render function.
     virtual void process(FrameRange range) = 0;
     


### PR DESCRIPTION
Non-realtime effects like time stretching require pulling more or less frames from the source node to function properly. So I added this option to the `internalRenderBlock` by adding `framesToPull` function with default implementation that returns unchanged frame count:

```
virtual AUAudioFrameCount framesToPull(AUAudioFrameCount requestedOutputFrameCount) { return requestedOutputFrameCount; };
```

For all effects that use default implementation nothing changes. 