### PR TITLE
Clear output buffer during CallbackInstrument DSP 

### DIFF
--- a/Sources/CAudioKitEX/Nodes/CallbackInstrumentDSP.mm
+++ b/Sources/CAudioKitEX/Nodes/CallbackInstrumentDSP.mm
@@ -36,6 +36,8 @@ public:
     }
 
     void process(FrameRange range) override {
+        zeroOutput(range.count, range.start);
+
         count += range.count;
         if (updateTime) {
             lastFrameCount = count;

--- a/Tests/AudioKitEXTests/CallbackInstrumentTests.swift
+++ b/Tests/AudioKitEXTests/CallbackInstrumentTests.swift
@@ -66,5 +66,20 @@ class CallbackInstrumentTests: XCTestCase {
         /// If the callback does get called, this will fail our test, adding insult to injury
         XCTAssertEqual(data, expectedData)
     }
+
+    func testClearsBuffer() {
+        let input = PlaygroundOscillator(waveform: Table([1, 1]))
+        let callback = CallbackInstrument()
+
+        let engine = AudioEngine()
+        let mixer = Mixer(input, callback)
+        engine.output = mixer
+
+        input.start()
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+
+        XCTAssertTrue(audio.toFloatChannelData()!.flatMap { $0 }.allSatisfy { $0 == 1 })
+    }
 }
 #endif


### PR DESCRIPTION
When connecting `CallbackInstrument` to the `Mixer` after another node, it will return the buffer as is. This will double the values inside the `Mixer`, and it can be fixed by filling the output buffer with zeros during DSP.