### PR TITLE
NoteEventSequence totalDuration calculation

### DIFF
--- a/Sources/AudioKitEX/Sequencing/Sequence.swift
+++ b/Sources/AudioKitEX/Sequencing/Sequence.swift
@@ -87,7 +87,10 @@ public struct NoteEventSequence: Equatable {
                              channel: MIDIChannel = 0,
                              position: Double,
                              duration: Double) {
-        totalDuration += duration
+        
+        let noteEndTime = position + duration
+        totalDuration = max(totalDuration, noteEndTime)
+        
         var newNote = SequenceNote()
 
         newNote.noteOn.status = noteOnByte

--- a/Sources/AudioKitEX/Sequencing/SequencerTrack.swift
+++ b/Sources/AudioKitEX/Sequencing/SequencerTrack.swift
@@ -85,7 +85,7 @@ open class SequencerTrack {
     /// Sequence on this track
     public var sequence = NoteEventSequence() {
         willSet {
-            if newValue.totalDuration != 0.0 && newValue.totalDuration >= length {
+            if newValue.totalDuration != 0.0 && newValue.totalDuration > length {
                  Log("Warning: Note event sequence duration exceeds the bounds of the sequencer track")
                  /// extend the length to accomodate the new notes
                  length = newValue.totalDuration

--- a/Sources/AudioKitEX/Sequencing/SequencerTrack.swift
+++ b/Sources/AudioKitEX/Sequencing/SequencerTrack.swift
@@ -85,10 +85,11 @@ open class SequencerTrack {
     /// Sequence on this track
     public var sequence = NoteEventSequence() {
         willSet {
-            if newValue.totalDuration >= length {
-                Log("Warning: Note event sequence duration exceeds the bounds of the sequencer track")
-                length = newValue.totalDuration + 0.01
-                Log("Track length set to \(length) beats")
+            if newValue.totalDuration != 0.0 && newValue.totalDuration >= length {
+                 Log("Warning: Note event sequence duration exceeds the bounds of the sequencer track")
+                 /// extend the length to accomodate the new notes
+                 length = newValue.totalDuration
+                 Log("Track length set to \(length) beats")
             }
         }
         didSet { updateSequence() }


### PR DESCRIPTION
Previously the SequencerTrack sequence.totalDuration was calculated by combining the duration of all notes in the sequence, even if those notes were overlapping vertically.  

So with enough chords early on in the sequence, the note's combined durations could exceed the SequencerTrack .length and cause the .length to be increased unnecessarily.  Extended tracks would then loop out of sync.  So now .add notes only increases the totalDuration value when the newly added noteEndTime > totalDuration.

Updated willSet condition of the sequence to only force the .length increase if the sequence.totalDuration is not 0.0.  Reason: Whenever calling .clear() the NoteEventSequence totalDuration is reset to 0.0.  Which previously caused the willSet to make the 0.01 increment increase to every empty track and print unnecessary log messages.

Also updated the .length increase value in the willSet, as the increase by 0.01 doesn't meaningfully help in the case of notes genuinely exceeding the track length.  So now the .length will match the new totalDuration.