### PR TITLE
Pass maxFramesToRender to DSP at allocation time

### DIFF
--- a/Sources/AudioKitEX/AudioKitAU.swift
+++ b/Sources/AudioKitEX/AudioKitAU.swift
@@ -39,7 +39,7 @@ open class AudioKitAU: AUAudioUnit {
         }
         
         if let outputFormat = outputBusArray.first?.format {
-            allocateRenderResourcesDSP(dsp, outputFormat.channelCount, outputFormat.sampleRate)
+            allocateRenderResourcesDSP(dsp, outputFormat.channelCount, outputFormat.sampleRate, maximumFramesToRender)
         }
     }
     

--- a/Sources/CAudioKitEX/Internals/DSPBase.mm
+++ b/Sources/CAudioKitEX/Internals/DSPBase.mm
@@ -25,8 +25,9 @@ void setBufferDSP(DSPRef pDSP, AudioBufferList* buffer, size_t busIndex)
     pDSP->setBuffer(buffer, busIndex);
 }
 
-void allocateRenderResourcesDSP(DSPRef pDSP, uint32_t channelCount, double sampleRate)
+void allocateRenderResourcesDSP(DSPRef pDSP, uint32_t channelCount, double sampleRate, AUAudioFrameCount maxFramesToRender)
 {
+    pDSP->setMaximumFramesToRender(maxFramesToRender);
     pDSP->init(channelCount, sampleRate);
 }
 

--- a/Sources/CAudioKitEX/include/DSPBase.h
+++ b/Sources/CAudioKitEX/include/DSPBase.h
@@ -18,7 +18,7 @@ size_t inputBusCountDSP(DSPRef pDSP);
 bool canProcessInPlaceDSP(DSPRef pDSP);
 
 void setBufferDSP(DSPRef pDSP, AudioBufferList* buffer, size_t busIndex);
-void allocateRenderResourcesDSP(DSPRef pDSP, uint32_t channelCount, double sampleRate);
+void allocateRenderResourcesDSP(DSPRef pDSP, uint32_t channelCount, double sampleRate, AUAudioFrameCount maxFramesToRender);
 void deallocateRenderResourcesDSP(DSPRef pDSP);
 void resetDSP(DSPRef pDSP);
 
@@ -89,6 +89,7 @@ protected:
 
     int channelCount;
     double sampleRate;
+    AUAudioFrameCount maximumFramesToRender = 0;
 
     bool isInitialized = false;
 
@@ -134,6 +135,12 @@ public:
     std::atomic<bool> isStarted{true};
     
     void setBuffer(AudioBufferList* buffer, size_t busIndex);
+
+    /// Set by AudioKitAU from AUAudioUnit.maximumFramesToRender before init().
+    /// Subclasses may read `maximumFramesToRender` in their init() override to
+    /// pre-size scratch buffers to the worst-case render size.
+    void setMaximumFramesToRender(AUAudioFrameCount frames) { maximumFramesToRender = frames; }
+    AUAudioFrameCount getMaximumFramesToRender() const { return maximumFramesToRender; }
     size_t getInputBusCount() const { return inputBufferLists.size(); }
 
     virtual AUAudioFrameCount framesToPull(AUAudioFrameCount requestedOutputFrameCount) { return requestedOutputFrameCount; };


### PR DESCRIPTION
Closes #16. AudioKitAU already knows maximumFramesToRender from the host but never forwarded it into C++, so DSP kernels had no sanctioned way to pre-size scratch buffers at init time and had to infer the worst case from the first render's output buffer.

Store the value as a member on DSPBase, set by allocateRenderResourcesDSP before init() is called. Subclasses opt in by reading maximumFramesToRender in their init() override — the virtual init(int, double) signature is unchanged, so existing overrides (including those in downstream projects) keep compiling.