### PR TITLE
Add mono-safe Gain node

### DIFF
--- a/Sources/AudioKitEX/Nodes/Gain.swift
+++ b/Sources/AudioKitEX/Nodes/Gain.swift
@@ -1,0 +1,74 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import AVFoundation
+import CAudioKitEX
+import AudioKit
+
+/// Multi-channel safe gain node. Applies a single ramped gain factor to every
+/// channel of the input buffer, regardless of channel count. Unlike `Fader`
+/// (which hard-codes stereo and crashes on mono input), this node iterates
+/// over the actual channel count reported by the audio unit.
+public class Gain: Node {
+
+    let input: Node
+
+    /// Connected nodes
+    public var connections: [Node] { [input] }
+
+    /// Underlying AVAudioNode
+    public var avAudioNode = instantiate(effect: "gain")
+
+    // MARK: - Parameters
+
+    /// Allow gain to be any non-negative number
+    public static let gainRange: ClosedRange<AUValue> = 0.0 ... Float.greatestFiniteMagnitude
+
+    /// Specification details for gain
+    public static let gainDef = NodeParameterDef(
+        identifier: "gain",
+        name: "Gain",
+        address: akGetParameterAddress("GainParameterGain"),
+        defaultValue: 1,
+        range: Gain.gainRange,
+        unit: .linearGain)
+
+    /// Amplification Factor applied to all channels
+    @Parameter(gainDef) public var gain: AUValue
+
+    /// Amplification Factor in dB - 0 is unity (gain = 1.0)
+    public var dB: AUValue {
+        get { 20.0 * log10(gain) }
+        set { gain = pow(10.0, newValue / 20.0) }
+    }
+
+    // MARK: - Initialization
+
+    /// Initialize this gain node
+    ///
+    /// - Parameters:
+    ///   - input: Node whose output will be amplified
+    ///   - gain: Amplification factor (Default: 1, Minimum: 0)
+    ///
+    public init(_ input: Node, gain: AUValue = 1) {
+        self.input = input
+
+        setupParameters()
+
+        self.gain = gain
+    }
+
+    // MARK: - Automation
+
+    /// Gain automation helper
+    /// - Parameters:
+    ///   - events: List of events
+    ///   - startTime: start time
+    public func automateGain(events: [AutomationEvent], startTime: AVAudioTime? = nil) {
+        $gain.automate(events: events, startTime: startTime)
+    }
+
+    /// Stop automation
+    public func stopAutomation() {
+        $gain.stopAutomation()
+    }
+}

--- a/Sources/CAudioKitEX/Nodes/GainDSP.mm
+++ b/Sources/CAudioKitEX/Nodes/GainDSP.mm
@@ -1,0 +1,30 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+#include "DSPBase.h"
+#include "ParameterRamper.h"
+
+enum GainParameter : AUParameterAddress {
+    GainParameterGain
+};
+
+struct GainDSP : DSPBase {
+private:
+    ParameterRamper gainRamp{1.0};
+
+public:
+    GainDSP() : DSPBase(1, true) {
+        parameters[GainParameterGain] = &gainRamp;
+    }
+
+    void process(FrameRange range) override {
+        for (auto i : range) {
+            float gain = gainRamp.getAndStep();
+            for (int channel = 0; channel < channelCount; ++channel) {
+                outputSample(channel, i) = inputSample(channel, i) * gain;
+            }
+        }
+    }
+};
+
+AK_REGISTER_DSP(GainDSP, "gain")
+AK_REGISTER_PARAMETER(GainParameterGain)

--- a/Tests/AudioKitEXTests/GainTests.swift
+++ b/Tests/AudioKitEXTests/GainTests.swift
@@ -1,0 +1,156 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKit/
+
+import Accelerate
+import AudioKit
+import AudioKitEX
+import AVFoundation
+import CAudioKitEX
+import XCTest
+
+class GainTests: XCTestCase {
+
+    private var savedAudioFormat: AVAudioFormat!
+
+    override func setUp() {
+        super.setUp()
+        savedAudioFormat = Settings.audioFormat
+        Settings.sampleRate = 44100
+    }
+
+    override func tearDown() {
+        Settings.audioFormat = savedAudioFormat
+        super.tearDown()
+    }
+
+    // MARK: - Mono regression (would crash with Fader)
+
+    func testMonoInputDoesNotCrash() {
+        Settings.channelCount = 1
+
+        let engine = AudioEngine()
+        let oscillator = PlaygroundOscillator(waveform: Table(.triangle))
+        engine.output = Gain(oscillator, gain: 1.0)
+
+        oscillator.start()
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+
+        XCTAssertEqual(audio.format.channelCount, 1)
+        XCTAssertFalse(audio.isSilent)
+    }
+
+    func testMonoGainHalvesAmplitude() {
+        Settings.channelCount = 1
+
+        let engine = AudioEngine()
+        let oscillator = PlaygroundOscillator(waveform: Table(.triangle))
+        let unityReference = rms(of: oscillator, gain: 1.0, engine: engine)
+
+        let engine2 = AudioEngine()
+        let oscillator2 = PlaygroundOscillator(waveform: Table(.triangle))
+        let halved = rms(of: oscillator2, gain: 0.5, engine: engine2)
+
+        XCTAssertEqual(halved, unityReference * 0.5, accuracy: unityReference * 0.05)
+    }
+
+    // MARK: - Stereo baseline
+
+    func testStereoDefault() {
+        Settings.channelCount = 2
+
+        let engine = AudioEngine()
+        let oscillator = PlaygroundOscillator(waveform: Table(.triangle))
+        engine.output = Gain(oscillator, gain: 1.0)
+
+        oscillator.start()
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+
+        XCTAssertEqual(audio.format.channelCount, 2)
+        XCTAssertFalse(audio.isSilent)
+    }
+
+    func testStereoZeroGainIsSilent() {
+        Settings.channelCount = 2
+
+        let engine = AudioEngine()
+        let oscillator = PlaygroundOscillator(waveform: Table(.triangle))
+        engine.output = Gain(oscillator, gain: 0.0)
+
+        oscillator.start()
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+
+        XCTAssertTrue(audio.isSilent)
+    }
+
+    // MARK: - Multichannel (4-channel quadraphonic)
+
+    func testMultiChannelInputDoesNotCrash() throws {
+        guard let layout = AVAudioChannelLayout(layoutTag: kAudioChannelLayoutTag_Quadraphonic) else {
+            throw XCTSkip("Quadraphonic layout not supported on this platform")
+        }
+        Settings.audioFormat = AVAudioFormat(standardFormatWithSampleRate: 44100, channelLayout: layout)
+
+        let engine = AudioEngine()
+        let oscillator = PlaygroundOscillator(waveform: Table(.triangle))
+        engine.output = Gain(oscillator, gain: 1.0)
+
+        oscillator.start()
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+
+        XCTAssertEqual(audio.format.channelCount, 4)
+        XCTAssertFalse(audio.isSilent)
+    }
+
+    // MARK: - Parameter ramping
+
+    func testGainRampsSmoothly() {
+        Settings.channelCount = 2
+
+        let engine = AudioEngine()
+        let oscillator = PlaygroundOscillator(waveform: Table(.triangle))
+        let gain = Gain(oscillator, gain: 0.0)
+        engine.output = gain
+
+        oscillator.start()
+        let audio = engine.startTest(totalDuration: 2.0)
+        gain.automateGain(events: [
+            AutomationEvent(targetValue: 1.0, startTime: 0, rampDuration: 2.0)
+        ])
+        audio.append(engine.render(duration: 2.0))
+
+        XCTAssertFalse(audio.isSilent)
+
+        // A linear gain ramp from 0 to 1 over the whole render should make the
+        // final quarter dramatically louder than the first quarter.
+        let quarter = Int(audio.frameLength) / 4
+        let firstQuarterRMS = rms(audio, range: 0 ..< quarter)
+        let lastQuarterRMS = rms(audio, range: (3 * quarter) ..< Int(audio.frameLength))
+        XCTAssertLessThan(firstQuarterRMS, lastQuarterRMS * 0.4)
+    }
+
+    // MARK: - Helpers
+
+    private func rms(of source: Node, gain: AUValue, engine: AudioEngine) -> Float {
+        engine.output = Gain(source, gain: gain)
+        (source as? PlaygroundOscillator)?.start()
+        let audio = engine.startTest(totalDuration: 1.0)
+        audio.append(engine.render(duration: 1.0))
+        return rms(audio, range: 0 ..< Int(audio.frameLength))
+    }
+
+    private func rms(_ buffer: AVAudioPCMBuffer, range: Range<Int>) -> Float {
+        guard let channelData = buffer.floatChannelData, !range.isEmpty else { return 0 }
+        let channelCount = Int(buffer.format.channelCount)
+        let length = vDSP_Length(range.count)
+        var sum: Float = 0
+        for channel in 0 ..< channelCount {
+            var channelRMS: Float = 0
+            vDSP_rmsqv(channelData[channel] + range.lowerBound, 1, &channelRMS, length)
+            sum += channelRMS
+        }
+        return sum / Float(channelCount)
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `Gain`, a simpler alternative to `Fader` whose DSP iterates over the audio unit's actual `channelCount` instead of hard-coding stereo channel access. Works for mono, stereo, and arbitrary multichannel input.
- Motivation: `FaderDSP::process` unconditionally reads `inputSample(1, i)`, which produces `EXC_BAD_ACCESS` when the input bus is configured for a single channel. We hit this on the iPhone Air built-in speaker, where Core Audio reports the output as a 1-channel "unknown layout" format and Apple's AUs don't auto-widen to stereo.
- `Gain` exposes a single ramped `gain` parameter (range `0...Float.greatestFiniteMagnitude`, unit `.linearGain`), a `dB` accessor, and the same `automateGain(events:startTime:)` / `stopAutomation()` surface as `Fader`. No `flipStereo` / `mixToMono` / independent L/R — kept intentionally small.
- Registered as 4-char code `"gain"` (no collision with existing AudioKitEX codes).
- `Fader` is untouched; this is purely additive.